### PR TITLE
Feat/refactor frontend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react-pdf": "^7.1.2",
         "react-router-dom": "^6.14.1",
         "react-scripts": "5.0.1",
+        "react-spinners": "^0.13.8",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -14974,6 +14975,15 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-spinners": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.13.8.tgz",
+      "integrity": "sha512-3e+k56lUkPj0vb5NDXPVFAOkPC//XyhKPJjvcGjyMNPWsBKpplfeyialP74G7H7+It7KzhtET+MvGqbKgAqpZA==",
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react-pdf": "^7.1.2",
     "react-router-dom": "^6.14.1",
     "react-scripts": "5.0.1",
+    "react-spinners": "^0.13.8",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/App.js
+++ b/src/App.js
@@ -4,15 +4,25 @@ import Footer from "./components/Footer";
 import HomePage from "./routes/HomePage";
 import SummaryPage from "./routes/SummaryPage";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { useState } from "react";
 
 function App() {
+  const [summary, setSummary] = useState("");
+
+  const handleSummary = (summaryResult) => {
+    setSummary(summaryResult);
+  };
+
   return (
     <div className="App">
       <BrowserRouter>
         <Header />
         <Routes>
-          <Route path="/" element={<HomePage />} />
-          <Route path="/summary" element={<SummaryPage />} />
+          <Route
+            path="/"
+            element={<HomePage onReceiveSummary={handleSummary} />}
+          />
+          <Route path="/summary" element={<SummaryPage summary={summary} />} />
         </Routes>
         <Footer />
       </BrowserRouter>

--- a/src/routes/HomePage.jsx
+++ b/src/routes/HomePage.jsx
@@ -1,6 +1,29 @@
-import FileUpload from "../components/FileUpload";
+import { useNavigate } from "react-router";
+import { useState } from "react";
 
-const Home = () => {
+const Home = ({ onReceiveSummary }) => {
+  const navigate = useNavigate();
+
+  const [selectedFile, setSelectedFile] = useState(null);
+
+  const handleFileChange = (e) => {
+    setSelectedFile(e.target.files[0]);
+  };
+
+  const handleSubmit = () => {
+    // TODO:
+    // 1. extract text from pdf file (selected file)
+    // 2. make summary from extracted text
+    // 3. this will happen in loading page
+    // 4. if loading is completed, give summary data to App.js
+    // 5. Finally, navigate to the summary page
+    const dummySummary = "this is a dummy summary";
+
+    onReceiveSummary(dummySummary);
+
+    navigate("/summary");
+  };
+
   return (
     <div id="work-area-wrapper" className="h-96">
       <div id="work-area">
@@ -10,7 +33,12 @@ const Home = () => {
             <div>subtitle</div>
           </div>
           <div>
-            <FileUpload />
+            <input
+              type="file"
+              onChange={handleFileChange}
+              className="bg-teal-200"
+            />
+            <button onClick={handleSubmit}>Upload</button>
           </div>
         </div>
       </div>

--- a/src/routes/HomePage.jsx
+++ b/src/routes/HomePage.jsx
@@ -1,5 +1,6 @@
 import { useNavigate } from "react-router";
 import { useState } from "react";
+import HashLoader from "react-spinners/HashLoader";
 
 const Home = ({ onReceiveSummary }) => {
   const navigate = useNavigate();
@@ -49,7 +50,9 @@ const Home = ({ onReceiveSummary }) => {
           </div>
           <div>
             {loading ? (
-              <div>loading...</div>
+              <div>
+                <HashLoader color="#36d7b7" />
+              </div>
             ) : (
               <>
                 <input

--- a/src/routes/HomePage.jsx
+++ b/src/routes/HomePage.jsx
@@ -6,22 +6,37 @@ const Home = ({ onReceiveSummary }) => {
 
   const [selectedFile, setSelectedFile] = useState(null);
 
+  const [loading, setLoading] = useState(false);
+
   const handleFileChange = (e) => {
     setSelectedFile(e.target.files[0]);
   };
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     // TODO:
     // 1. extract text from pdf file (selected file)
     // 2. make summary from extracted text
     // 3. this will happen in loading page
     // 4. if loading is completed, give summary data to App.js
     // 5. Finally, navigate to the summary page
-    const dummySummary = "this is a dummy summary";
+    const dummySummary = "this is a dummy summary2";
 
-    onReceiveSummary(dummySummary);
+    if (selectedFile) {
+      setLoading(true);
+      console.log(loading);
 
-    navigate("/summary");
+      try {
+        // should be text extraction and summary logic
+        setTimeout(() => {
+          setLoading(false);
+          console.log(loading);
+          onReceiveSummary(dummySummary);
+          navigate("/summary");
+        }, 1000);
+      } catch (error) {
+        console.error(error);
+      }
+    }
   };
 
   return (
@@ -33,12 +48,18 @@ const Home = ({ onReceiveSummary }) => {
             <div>subtitle</div>
           </div>
           <div>
-            <input
-              type="file"
-              onChange={handleFileChange}
-              className="bg-teal-200"
-            />
-            <button onClick={handleSubmit}>Upload</button>
+            {loading ? (
+              <div>loading...</div>
+            ) : (
+              <>
+                <input
+                  type="file"
+                  onChange={handleFileChange}
+                  className="bg-teal-200"
+                />
+                <button onClick={handleSubmit}>Upload</button>
+              </>
+            )}
           </div>
         </div>
       </div>

--- a/src/routes/SummaryPage.jsx
+++ b/src/routes/SummaryPage.jsx
@@ -1,13 +1,14 @@
 import FileSaver from "file-saver";
 import CopyToClipboard from "react-copy-to-clipboard";
 
-const Summary = () => {
-  // now we are testing with dummyText instead of SummaryText
-  const dummyText = "This is a dummy text";
-
+const Summary = ({ summary }) => {
+  // if no summary is provided
+  if (!summary) {
+    return <div>there is no summary available</div>;
+  }
   // function to save text as a .txt file
   const exportTxt = () => {
-    const blob = new Blob([dummyText], { type: "text/plain;charset=utf-8" });
+    const blob = new Blob([summary], { type: "text/plain;charset=utf-8" });
     FileSaver.saveAs(blob, "summary.txt");
   };
 
@@ -15,17 +16,17 @@ const Summary = () => {
     <div id="summary-area-wrapper" className="h-96">
       <div className="h-36">Summary Completed!</div>
       <div className="flex items-center justify-between w-full">
-        <div>example</div>
+        <div>{summary}</div>
         <div className="flex-col items-center justify-between">
           <button className="button" onClick={() => exportTxt()}>
             export
           </button>
           <CopyToClipboard
             className="button"
-            text={dummyText}
+            text={summary}
             onCopy={() => alert("copied to clipboard")}
           >
-            <text>Copy</text>
+            <span>Copy</span>
           </CopyToClipboard>
           <button>c</button>
         </div>


### PR DESCRIPTION
## Description

1. App.js 에 file, setfile을 만들어서 HomePage로부터 SummaryPage로 data가 넘어갈 수 있게 바꿈
2. FileUpload 컴포넌트 제거
3. 함수들 이름 직관적으로 rename
4. loading logic, spinner 구현
5. 예외 처리 조금 추가
6. Navigate 활용하여 Summary 다 되면 자동으로 /summary로 이동하는 로직 구현

<!-- Add a more detailed description of the changes if needed. -->

현재는 HomePage의 handlesubmit에 setTimeOut이 들어가있음. 이 자리에 API 호출 및 여러 로직이 들어갈 예정
HomePage에서 SummaryPage로 넘기는 데이터의 형식이 어떤 것이 될지 알아야 할듯

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->
